### PR TITLE
C2C-346: E2e tests for the Bahmni-OpenELIS flows .

### DIFF
--- a/.env
+++ b/.env
@@ -36,5 +36,5 @@ ODOO_USERNAME=admin
 ODOO_PASSWORD=admin
 
 # OpenELIS test user credentials
-OpenELIS_USERNAME=admin
-OpenELIS_PASSWORD=adminADMIN!
+OPENELIS_USERNAME=admin
+OPENELIS_PASSWORD=adminADMIN!

--- a/e2e/tests/bahmni-openelis-flows.spec.ts
+++ b/e2e/tests/bahmni-openelis-flows.spec.ts
@@ -1,0 +1,209 @@
+import { test, expect } from '@playwright/test';
+import { Bahmni, patientName } from '../utils/functions/bahmni';
+import { OpenELIS } from '../utils/functions/openelis';
+import { BAHMNI_URL, OPENELIS_URL } from '../utils/configs/globalSetup';
+
+let bahmni: Bahmni;
+let openelis: OpenELIS;
+
+test.beforeEach(async ({ page }) => {
+  bahmni = new Bahmni(page);
+  openelis = new OpenELIS(page);
+
+  await bahmni.login();
+  await expect(page.getByText(/registration/i)).toBeVisible();
+  await expect(page.getByText(/linical/i)).toBeVisible();
+  await expect(page.getByText(/admin/i)).toBeVisible();
+  await expect(page.getByText(/appointment scheduling/i)).toBeVisible();
+  await expect(page.getByText(/patient documents/i)).toBeVisible();
+  await bahmni.registerPatient();
+  await bahmni.navigateToPatientDashboard();
+});
+
+test('Ordering a lab test for a Bahmni patient creates the corresponding OpenElis client with an analysis request.', async ({ page }) => {
+  // setup
+  await bahmni.navigateToLabSamples();
+
+  // replay
+  await bahmni.createLabOrder();
+
+  // verify
+  await openelis.open();
+  await expect(page).toHaveURL(/.*openelis/);
+  await openelis.searchClient();
+
+  const clientSelector = await page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1");
+  await expect(clientSelector).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+
+  await page.locator('#todaySamplesToCollectListContainer-slick-grid div.slick-viewport div.slick-cell.l6.r6.cell-title a').click();
+  await expect(page.locator('#tests_1')).toHaveValue('Malaria')
+});
+
+
+test('Editing the details of a Bahmni patient with a synced lab order edits the corresponding OpenELIS client details.', async ({ page }) => {
+  // setup
+  await bahmni.navigateToLabSamples();
+  await bahmni.createLabOrder();
+  await openelis.open();
+  await expect(page).toHaveURL(/.*openelis/);
+  await openelis.searchClient();
+  const clientSelector = await page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1");
+  await expect(clientSelector).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+
+  // replay
+  await page.goto(`${BAHMNI_URL}`);
+  await bahmni.updatePatientDetails();
+
+  // verify
+  await openelis.open();
+  await openelis.searchClient();
+  await expect(clientSelector).toHaveText(`${patientName.updatedGivenName}` + ' ' + `${patientName.familyName}`);
+});
+
+test('Revising a synced Bahmni lab order edits the corresponding OpenELIS client analysis request.', async ({ page }) => {
+  // setup
+  await bahmni.navigateToLabSamples();
+  await bahmni.createLabOrder();
+  await openelis.open();
+  await expect(page).toHaveURL(/.*openelis/);
+  await openelis.searchClient();
+  const clientSelector = await page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1");
+  await expect(clientSelector).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+  await page.locator('#todaySamplesToCollectListContainer-slick-grid div.slick-viewport div.slick-cell.l6.r6.cell-title a').click();
+  await expect(page.locator('#tests_1')).toHaveValue('Malaria')
+
+  // replay
+  await bahmni.navigateToPatientDashboard();
+  await bahmni.navigateToLabSamples();
+  await bahmni.reviseLabOrder();
+
+  // verify
+  await openelis.open();
+  await openelis.searchClient();
+  await expect(clientSelector).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+
+  await page.locator('#todaySamplesToCollectListContainer-slick-grid div.slick-viewport div.slick-cell.l6.r6.cell-title a').click();
+  await expect(page.locator('#tests_1')).toHaveValue('Hematocrite');
+});
+
+test('Voiding a synced OpenMRS lab order cancels the corresponding OpenElis analysis request.', async ({ page }) => {
+  // setup
+  await bahmni.navigateToLabSamples();
+  await bahmni.createLabOrder();
+  await openelis.open();
+  await expect(page).toHaveURL(/.*openelis/);
+  await openelis.searchClient();
+  const clientSelector = await page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1");
+  await expect(clientSelector).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+  await page.locator('#todaySamplesToCollectListContainer-slick-grid div.slick-viewport div.slick-cell.l6.r6.cell-title a').click();
+  await expect(page.locator('#tests_1')).toHaveValue('Malaria')
+
+  // replay
+  await bahmni.navigateToPatientDashboard();
+  await bahmni.navigateToLabSamples();
+  await bahmni.discontinueLabOrder();
+
+  // verify
+  await openelis.open();
+  await openelis.searchClient();
+  await expect(page.getByText(`${patientName.givenName + ' ' + patientName.familyName}`)).not.toBeVisible();
+});
+
+test('Published coded lab results from OpenELIS are viewable in the Bahmni lab results viewer.', async ({ page }) => {
+  // setup
+  await bahmni.navigateToLabSamples();
+  await bahmni.createLabOrder();
+
+  // replay
+  await openelis.open();
+  await expect(page).toHaveURL(/.*openelis/);
+  await openelis.searchClient();
+
+  const clientSelector = await page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1");
+  await expect(clientSelector).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+  await openelis.collectSample();
+  await page.locator('a#todaySamplesCollectedListContainerId').click();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+
+  await openelis.enterLabResults();
+  await page.locator('a#todaySamplesCollectedListContainerId').click();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+  await openelis.validateLabResults();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+  const status = await page.locator('#todaySamplesCollectedListContainer-slick-grid div.slick-viewport div div:nth-child(1) div.slick-cell.l8.r8.cell-title');
+  await expect(status).toHaveText('Yes');
+
+  // verify
+  await bahmni.navigateToPatientDashboard();
+  await expect(page.locator('#Lab-Results').getByText('Malaria')).toBeVisible();
+  await expect(page.locator('#Lab-Results span.value')).toHaveText('Negatif');
+});
+
+test('Published numerical lab results from OpenELIS are viewable in the Bahmni lab results viewer.', async ({ page }) => {
+  // setup
+  await bahmni.navigateToLabSamples();
+  await page.getByText('Blood', { exact: true }).click();
+  await page.getByText('Lymphocites').click();
+  await bahmni.saveOrder();
+
+  // replay
+  await openelis.open();
+  await expect(page).toHaveURL(/.*openelis/);
+  await openelis.searchClient();
+
+  const clientSelector = await page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1");
+  await expect(clientSelector).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+  await openelis.collectSample();
+  await page.locator('a#todaySamplesCollectedListContainerId').click();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+
+  await openelis.enterNumericalResults();
+  await page.locator('a#todaySamplesCollectedListContainerId').click();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+  await openelis.validateLabResults();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+  const status = await page.locator('#todaySamplesCollectedListContainer-slick-grid div.slick-viewport div div:nth-child(1) div.slick-cell.l8.r8.cell-title');
+  await expect(status).toHaveText('Yes');
+
+  // verify
+  await bahmni.navigateToPatientDashboard();
+  await expect(page.locator('#Lab-Results').getByText('Lymphocytes')).toBeVisible();
+  await expect(page.locator('#Lab-Results span.value')).toHaveText('13.7');
+});
+
+test('Published free text lab results from OpenELIS are viewable in the Bahmni lab results viewer.', async ({ page }) => {
+  // setup
+  await bahmni.navigateToLabSamples();
+  await page.getByText('Urine', { exact: true }).click();
+  await page.getByText('Urobilinogen').click();
+  await bahmni.saveOrder();
+
+  // replay
+  await openelis.open();
+  await expect(page).toHaveURL(/.*openelis/);
+  await openelis.searchClient();
+
+  const clientSelector = await page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1");
+  await expect(clientSelector).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+  await openelis.collectSample();
+  await page.locator('a#todaySamplesCollectedListContainerId').click();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+
+  await openelis.enterFreeTextResults();
+  await page.locator('a#todaySamplesCollectedListContainerId').click();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+  await openelis.validateLabResults();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+  const status = await page.locator('#todaySamplesCollectedListContainer-slick-grid div.slick-viewport div div:nth-child(1) div.slick-cell.l8.r8.cell-title');
+  await expect(status).toHaveText('Yes');
+
+  // verify
+  await bahmni.navigateToPatientDashboard();
+  await expect(page.locator('#Lab-Results').getByText('Urobilinogen')).toBeVisible();
+  await expect(page.locator('#Lab-Results span.value')).toHaveText('Abnormal level');
+});
+
+test.afterEach(async ({ page }) => {
+  await bahmni.voidPatient();
+  await page.close();
+});

--- a/e2e/tests/diagnosis.spec.ts
+++ b/e2e/tests/diagnosis.spec.ts
@@ -20,6 +20,7 @@ test('Create and revise a diagnosis.', async ({ page }) => {
   await bahmni.registerPatient();
 
   // replay
+  await bahmni.navigateToPatientDashboard();
   await bahmni.navigateToDiagnosis();
   await page.locator('#name-0').fill('Candidiasis (B37.9)');
   await page.getByText('Candidiasis (B37.9)').click();

--- a/e2e/tests/lab-orders.spec.ts
+++ b/e2e/tests/lab-orders.spec.ts
@@ -19,8 +19,8 @@ test('Create, revise and discontinue lab tests.', async ({ page }) => {
   await bahmni.registerPatient();
 
   // replay
-  await bahmni.goToHomePage();
-  await bahmni.goToLabSamples();
+  await bahmni.navigateToPatientDashboard();
+  await bahmni.navigateToLabSamples();
   await page.getByText('Blood', { exact: true }).click();
   await page.getByText('Malaria').click();
   await page.getByText('Urine').click();

--- a/e2e/tests/medications.spec.ts
+++ b/e2e/tests/medications.spec.ts
@@ -19,7 +19,7 @@ test('Create, revise and discontinue a drug order.', async ({ page }) => {
   await bahmni.registerPatient();
 
   // replay
-  await bahmni.goToHomePage();
+  await bahmni.navigateToPatientDashboard();
   await bahmni.navigateToMedications();
   await bahmni.createMedication();
 

--- a/e2e/utils/configs/globalSetup.ts
+++ b/e2e/utils/configs/globalSetup.ts
@@ -13,6 +13,7 @@ dotenv.config();
 
 export const BAHMNI_URL = `${process.env.TEST_ENVIRONMENT}` == 'uat' ? `${process.env.BAHMNI_URL_UAT}` : `${process.env.BAHMNI_URL_DEV}`;
 export const ODOO_URL = `${process.env.TEST_ENVIRONMENT}` == 'uat' ? `${process.env.ODOO_URL_UAT}` : `${process.env.ODOO_URL_DEV}`;
+export const OPENELIS_URL = `${process.env.TEST_ENVIRONMENT}` == 'uat' ? `${process.env.OPENELIS_URL_UAT}` : `${process.env.OPENELIS_URL_DEV}`;
 
 async function globalSetup() {
   const requestContext = await request.newContext();

--- a/e2e/utils/functions/bahmni.ts
+++ b/e2e/utils/functions/bahmni.ts
@@ -20,7 +20,6 @@ export class Bahmni {
 
   async login() {
     await this.page.goto(`${BAHMNI_URL}`)
-    await this.page.locator('#locale').selectOption('string:en');
     await this.page.locator('#username').fill(`${process.env.BAHMNI_USERNAME}`);
     await this.page.locator('#password').fill(`${process.env.BAHMNI_PASSWORD}`);
     await this.page.locator('#location').selectOption('object:7');
@@ -59,10 +58,10 @@ export class Bahmni {
     await expect(this.page.locator('#givenName')).toBeVisible();
     await this.page.locator('#givenName').clear();
     await delay(1000);
-    await this.page.locator('#givenName').fill(`${patientName.updatedGivenName}`);
+    await this.page.locator('#givenName').type(`${patientName.updatedGivenName}`);
     await this.page.getByRole('button', { name: 'Save' }).click();
     patientName.givenName = `${patientName.updatedGivenName}`;
-    await delay(3000);
+    await delay(8000);
   };
 
   async voidPatient() {
@@ -75,9 +74,13 @@ export class Bahmni {
     await expect(message?.includes('This patient has been deleted')).toBeTruthy();
   }
 
-  async goToLabSamples() {
+  async navigateToPatientDashboard() {
+    await this.page.goto(`${BAHMNI_URL}/bahmni/home`);
     await this.page.getByRole('link', { name: 'Clinical' }).click();
     await this.searchPatient();
+  }
+
+  async navigateToLabSamples() {
     await this.page.locator('#view-content :nth-child(1).btn--success').click();
     await this.page.locator('#opd-tabs').getByText('Orders').click();
     await expect(this.page.getByText('Lab Samples')).toBeVisible();
@@ -100,24 +103,15 @@ export class Bahmni {
     await this.page.getByText('Blood', { exact: true }).click();
     await this.page.locator('#selected-orders li').filter({ hasText: 'Malaria' }).locator('i').nth(1).click();
     await this.saveOrder();
-  }
-
-  async goToHomePage() {
-    await this.page.goto(`${BAHMNI_URL}/bahmni/home`);
-    await expect(this.page).toHaveURL(/.*home/);
+    await delay(4000);
   }
 
   async navigateToDiagnosis() {
-    await this.page.locator('i.fa.fa-home').click();
-    await this.page.getByRole('link', { name: 'Clinical' }).click();
-    await this.searchPatient();
     await this.page.locator('#view-content :nth-child(1).btn--success').click();
     await this.page.locator('#opd-tabs').getByText('Diagnosis').click();
   }
 
   async navigateToMedications() {
-    await this.page.getByRole('link', { name: 'Clinical' }).click();
-    await this.searchPatient();
     await this.page.locator('#view-content :nth-child(1).btn--success').click();
     await this.page.locator('#opd-tabs').getByText('Medications').click();
     await expect(this.page.getByText('Order Drug')).toBeVisible();
@@ -165,6 +159,6 @@ export class Bahmni {
   async saveOrder() {
     await this.page.getByRole('button', { name: 'Save' }).click();
     await expect(this.page.getByText('Saved', {exact: true})).toBeVisible();
-    await delay(5000);
+    await delay(8000);
   }
 }

--- a/e2e/utils/functions/odoo.ts
+++ b/e2e/utils/functions/odoo.ts
@@ -1,5 +1,5 @@
-import { Page } from '@playwright/test';
-import { patientName } from './bahmni';
+import { expect, Page } from '@playwright/test';
+import { delay, patientName } from './bahmni';
 import { ODOO_URL } from '../configs/globalSetup';
 
 export class Odoo {
@@ -10,12 +10,15 @@ export class Odoo {
     await this.page.getByPlaceholder('Email').fill(`${process.env.ODOO_USERNAME}`);
     await this.page.getByPlaceholder('Password').fill(`${process.env.ODOO_PASSWORD}`);
     await this.page.locator('button[type="submit"]').click();
+    await expect(this.page).toHaveURL(/.*web#action/);
   }
 
   async searchCustomer() {
     await this.page.locator("//a[contains(@class, 'full')]").click();
+    await delay(2000);
     await this.page.locator('ul.o_menu_apps a:nth-child(2)').click();
-    await this.page.locator('input.o_searchview_input').fill(`${patientName.givenName + ' ' + patientName.familyName}`);
+    await expect(this.page.locator('.breadcrumb-item')).toHaveText('Devis');
+    await this.page.locator('input.o_searchview_input').type(`${patientName.givenName + ' ' + patientName.familyName}`);
     await this.page.locator('input.o_searchview_input').press('Enter');
   }
 }

--- a/e2e/utils/functions/openelis.ts
+++ b/e2e/utils/functions/openelis.ts
@@ -1,0 +1,57 @@
+import { expect, Page } from '@playwright/test';
+import { OPENELIS_URL } from '../configs/globalSetup';
+import { delay, patientName } from './bahmni';
+
+export class OpenELIS {
+  constructor(readonly page: Page) {}
+
+  async open() {
+    await this.page.goto(`${OPENELIS_URL}`);
+    await this.page.locator("input[name='loginName']").fill(`${process.env.OPENELIS_USERNAME}`);
+    await this.page.locator("input[name='password']").fill(`${process.env.OPENELIS_PASSWORD}`);
+    await this.page.locator('#submitButton').click();
+    await delay(6000);
+  }
+
+  async searchClient() {
+    await this.page.locator('#menu_labDashboard').click();
+    await delay(5000);
+    await this.page.locator('input#refreshButton').click();
+    await expect(this.page.locator('input[type=text]').nth(1)).toBeVisible();
+    await this.page.locator('input[type=text]').nth(1).type(`${patientName.givenName + ' ' + patientName.familyName}`);
+  }
+
+  async collectSample() {
+    await this.page.locator('#todaySamplesToCollectListContainer-slick-grid div.slick-viewport div.slick-cell.l6.r6.cell-title a').click();
+    await this.page.locator('#orderDisplay tbody input.textButton').click();
+    await this.page.locator('#saveButtonId').first().click();
+  }
+
+  async enterLabResults() {
+    await this.page.locator('#result').first().click();
+    await this.page.locator('#results_1').selectOption('Negatif');
+    await this.page.locator('#saveButtonId').first().click();
+  }
+
+  async enterNumericalResults() {
+    await this.page.locator('#result').first().click();
+    await this.page.locator('#results_1').click();
+    await this.page.locator('#results_1').fill('13.7');
+    await this.page.locator('#cell_1').click();
+    await this.page.locator('#saveButtonId').first().click();
+  }
+
+  async enterFreeTextResults() {
+    await this.page.locator('#result').first().click();
+    await this.page.locator('#results_1').fill('Abnormal level');
+    await this.page.locator('#abnormalId_1').click();
+    await this.page.locator('#saveButtonId').first().click();
+  }
+
+  async validateLabResults() {
+    await this.page.locator('a#validate').first().click();
+    await this.page.locator('#accepted_0').check();
+    await this.page.locator('#saveButtonId').first().click();
+    await delay(8000);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MPL-2.0",
   "description": "These are end-to-end automated tests covering Bahmni distro C2C workflows",
   "scripts": {
-    "e2e-tests-c2c": "npx playwright test"
+    "e2e-tests-c2c": "npx playwright test openelis"
   },
   "keywords": [],
   "devDependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@ dotenv.config();
 
 const config: PlaywrightTestConfig = {
   testDir: './e2e/tests',
-  timeout: 3 * 60 * 1000,
+  timeout: 4 * 60 * 1000,
   expect: {
     timeout: 40 * 1000,
   },
@@ -22,7 +22,7 @@ const config: PlaywrightTestConfig = {
     {
       name: 'chromium',
       use: {
-        ...devices['Desktop Chromium'],
+        ...devices['Desktop Chromium']
       },
     },
   ],


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/C2C-346

Description: This PR adds E2E tests for Bahmni-OpenELIS flows and covers the following test cases;

-  Ordering a lab test for a Bahmni patient creates the corresponding OpenELIS client with a filled analysis request
-  Editing the details of a Bahmni patient with a synced lab order edits the corresponding OpenELIS client details.
-  Revising a synced Bahmni lab order edits the corresponding OpenELIS client analysis request.
-  Voiding a synced OpenMRS lab order cancels the corresponding OpenElis analysis request.
-   Published coded lab results from OpenELIS are viewable in the Bahmni lab results viewer.
-   Published numeric lab results from OpenELIS are viewable in the Bahmni lab results lab results viewer.
-   Published free lab results from OpenELIS are viewable in the Bahmni lab results viewer.
