### PR TITLE
C2C-346: E2E tests for Bahmni-OpenELIS flows

### DIFF
--- a/.env
+++ b/.env
@@ -36,5 +36,5 @@ ODOO_USERNAME=admin
 ODOO_PASSWORD=admin
 
 # OpenELIS test user credentials
-OpenELIS_USERNAME=admin
-OpenELIS_PASSWORD=adminADMIN!
+OPENELIS_USERNAME=admin
+OPENELIS_PASSWORD=adminADMIN!

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,4 +57,4 @@ jobs:
         with:
           name: playwright-report
           path: playwright-report/
-          retention-days: 30
+          retention-days: 7

--- a/e2e/tests/bahmni-odoo-flows.spec.ts
+++ b/e2e/tests/bahmni-odoo-flows.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
+import { BAHMNI_URL, ODOO_URL } from '../utils/configs/globalSetup';
 import { Odoo } from '../utils/functions/odoo';
 import { Bahmni, patientName } from '../utils/functions/bahmni';
-import { BAHMNI_URL, ODOO_URL } from '../utils/configs/globalSetup';
 
 let odoo: Odoo;
 let bahmni: Bahmni;

--- a/e2e/tests/bahmni-openelis-flows.spec.ts
+++ b/e2e/tests/bahmni-openelis-flows.spec.ts
@@ -1,0 +1,184 @@
+import { test, expect } from '@playwright/test';
+import { BAHMNI_URL } from '../utils/configs/globalSetup';
+import { Bahmni, delay, patientName } from '../utils/functions/bahmni';
+import { OpenELIS } from '../utils/functions/openelis';
+
+let bahmni: Bahmni;
+let openelis: OpenELIS;
+
+test.beforeEach(async ({ page }) => {
+  bahmni = new Bahmni(page);
+  openelis = new OpenELIS(page);
+
+  await bahmni.login();
+  await expect(page.getByText(/registration/i)).toBeVisible();
+  await expect(page.getByText(/clinical/i)).toBeVisible();
+  await expect(page.getByText(/admin/i)).toBeVisible();
+  await expect(page.getByText(/patient documents/i)).toBeVisible();
+  await bahmni.registerPatient();
+  await bahmni.navigateToPatientDashboard();
+});
+
+test('Ordering a lab test for a Bahmni patient creates the corresponding OpenElis client with an analysis request.', async ({ page }) => {
+  // setup
+  await bahmni.navigateToLabSamples();
+
+  // replay
+  await bahmni.createLabOrder();
+
+  // verify
+  await openelis.open();
+  await openelis.searchClient();
+  await expect(page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1")).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+  await page.locator('#todaySamplesToCollectListContainer-slick-grid div.slick-viewport div.slick-cell.l6.r6.cell-title a').click();
+  await expect(page.locator('#tests_1')).toHaveValue('Malaria')
+});
+
+
+test('Editing the details of a Bahmni patient with a synced lab order edits the corresponding OpenELIS client details.', async ({ page }) => {
+  // setup
+  await bahmni.navigateToLabSamples();
+  await bahmni.createLabOrder();
+  await openelis.open();
+  await openelis.searchClient();
+  await expect(page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1")).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+
+  // replay
+  await page.goto(`${BAHMNI_URL}`);
+  await bahmni.updatePatientDetails();
+
+  // verify
+  await openelis.open();
+  await openelis.searchClient();
+  await expect(page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1")).toHaveText(`${patientName.updatedGivenName}` + ' ' + `${patientName.familyName}`);
+});
+
+test('Revising a synced Bahmni lab order edits the corresponding OpenELIS client analysis request.', async ({ page }) => {
+  // setup
+  await bahmni.navigateToLabSamples();
+  await bahmni.createLabOrder();
+  await openelis.open();
+  await openelis.searchClient();
+  await expect(page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1")).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+  await page.locator('#todaySamplesToCollectListContainer-slick-grid div.slick-viewport div.slick-cell.l6.r6.cell-title a').click();
+  await expect(page.locator('#tests_1')).toHaveValue('Malaria')
+
+  // replay
+  await bahmni.navigateToPatientDashboard();
+  await bahmni.navigateToLabSamples();
+  await bahmni.reviseLabOrder();
+
+  // verify
+  await openelis.open();
+  await openelis.searchClient();
+  await expect(page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1")).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+  await page.locator('#todaySamplesToCollectListContainer-slick-grid div.slick-viewport div.slick-cell.l6.r6.cell-title a').click();
+  await expect(page.locator('#tests_1')).toHaveValue('Hematocrite');
+});
+
+test('Voiding a synced OpenMRS lab order cancels the corresponding OpenElis analysis request.', async ({ page }) => {
+  // setup
+  await bahmni.navigateToLabSamples();
+  await bahmni.createLabOrder();
+  await openelis.open();
+  await openelis.searchClient();
+  await expect(page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1")).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+  await page.locator('#todaySamplesToCollectListContainer-slick-grid div.slick-viewport div.slick-cell.l6.r6.cell-title a').click();
+  await expect(page.locator('#tests_1')).toHaveValue('Malaria')
+
+  // replay
+  await bahmni.navigateToPatientDashboard();
+  await bahmni.navigateToLabSamples();
+  await bahmni.discontinueLabOrder();
+
+  // verify
+  await openelis.open();
+  await openelis.searchClient();
+  await expect(page.getByText(`${patientName.givenName + ' ' + patientName.familyName}`)).not.toBeVisible();
+});
+
+test('Published coded lab results from OpenELIS are viewable in the Bahmni lab results viewer.', async ({ page }) => {
+  // setup
+  await bahmni.navigateToLabSamples();
+  await bahmni.createLabOrder();
+
+  // replay
+  await openelis.open();
+  await openelis.searchClient();
+  await expect(page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1")).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+  await openelis.collectSample();
+  await page.locator('a#todaySamplesCollectedListContainerId').click();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+  await openelis.enterCodedResults();
+  await page.locator('a#todaySamplesCollectedListContainerId').click();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+  await openelis.validateLabResults();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+  await expect(page.locator('#todaySamplesCollectedListContainer-slick-grid div.slick-viewport div div:nth-child(1) div.slick-cell.l8.r8.cell-title')).toHaveText('Yes');
+
+  // verify
+  await bahmni.navigateToPatientDashboard();
+  await expect(page.locator('#Lab-Results').getByText('Malaria')).toBeVisible();
+  await expect(page.locator('#Lab-Results span.value')).toHaveText('Negatif');
+});
+
+test('Published numerical lab results from OpenELIS are viewable in the Bahmni lab results viewer.', async ({ page }) => {
+  // setup
+  await bahmni.navigateToLabSamples();
+  await page.getByText('Blood', { exact: true }).click();
+  await page.getByText('Lymphocites').click();
+  await bahmni.save();
+  await delay(5000);
+
+  // replay
+  await openelis.open();
+  await openelis.searchClient();
+  await expect(page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1")).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+  await openelis.collectSample();
+  await page.locator('a#todaySamplesCollectedListContainerId').click();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+  await openelis.enterNumericalResults();
+  await page.locator('a#todaySamplesCollectedListContainerId').click();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+  await openelis.validateLabResults();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+  await expect(page.locator('#todaySamplesCollectedListContainer-slick-grid div.slick-viewport div div:nth-child(1) div.slick-cell.l8.r8.cell-title')).toHaveText('Yes');
+
+  // verify
+  await bahmni.navigateToPatientDashboard();
+  await expect(page.locator('#Lab-Results').getByText('Lymphocytes')).toBeVisible();
+  await expect(page.locator('#Lab-Results span.value')).toHaveText('13.7');
+});
+
+test('Published free text lab results from OpenELIS are viewable in the Bahmni lab results viewer.', async ({ page }) => {
+  // setup
+  await bahmni.navigateToLabSamples();
+  await page.getByText('Urine', { exact: true }).click();
+  await page.getByText('Urobilinogen').click();
+  await bahmni.save();
+  await delay(5000);
+
+  // replay
+  await openelis.open();
+  await openelis.searchClient();
+  await expect(page.locator("#todaySamplesToCollectListContainer-slick-grid div.slick-cell.l1.r1")).toHaveText(`${patientName.givenName + ' ' + patientName.familyName}`);
+  await openelis.collectSample();
+  await page.locator('a#todaySamplesCollectedListContainerId').click();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+  await openelis.enterFreeTextResults();
+  await page.locator('a#todaySamplesCollectedListContainerId').click();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+  await openelis.validateLabResults();
+  await page.locator('#todaySamplesCollectedListContainer-slick-grid div.ui-state-default.slick-headerrow-column.l2.r2 input[type=text]').type(`${patientName.familyName}`);
+  await expect(page.locator('#todaySamplesCollectedListContainer-slick-grid div.slick-viewport div div:nth-child(1) div.slick-cell.l8.r8.cell-title')).toHaveText('Yes');
+
+  // verify
+  await bahmni.navigateToPatientDashboard();
+  await expect(page.locator('#Lab-Results').getByText('Urobilinogen')).toBeVisible();
+  await expect(page.locator('#Lab-Results span.value')).toHaveText('Abnormal level');
+});
+
+test.afterEach(async ({ page }) => {
+  await bahmni.voidPatient();
+  await page.close();
+});

--- a/e2e/tests/observation-forms.spec.ts
+++ b/e2e/tests/observation-forms.spec.ts
@@ -246,7 +246,7 @@ test('Prenatal consultation form should save observations.', async ({ page }) =>
   await expect(page.locator('#observationSection').getByText('Number of Weeks')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('18', {exact: true}).nth(0)).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Risky Pregnancy')).toBeVisible();
-  await expect(page.locator('#observationSection').getByText('No')).toBeVisible();
+  await expect(page.locator('#observationSection').getByText('No', { exact: true })).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Signs and Symptoms', {exact:true})).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Abdominal pain')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Duration')).toBeVisible();

--- a/e2e/tests/observation-forms.spec.ts
+++ b/e2e/tests/observation-forms.spec.ts
@@ -26,10 +26,7 @@ test('Anthropometry form should save observations.', async ({ page }) => {
   await bahmni.fillAnthropometryForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.locator('#observationSection h2')).toHaveText('Observations');
   await expect(page.locator('#observationSection').getByText('BMI Data')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('22.49')).toBeVisible();
@@ -40,7 +37,7 @@ test('Anthropometry form should save observations.', async ({ page }) => {
   await expect(page.locator('#observationSection').getByText('Weight')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('65')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Head Circumference')).toBeVisible();
-  await expect(page.locator('#observationSection').getByText('23')).toBeVisible();
+  await expect(page.locator('#observationSection').getByText('23', { exact: true })).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Abdominal Diameter')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('25.5')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Mid-Upper Arm Circumference')).toBeVisible();
@@ -58,10 +55,7 @@ test('Gynecological ultrasound form should save observations.', async ({ page })
   await bahmni.fillGynecologicalUltrasoundForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Echographie gynécologique')).toBeVisible();
   await expect(page.locator('div:nth-child(2) span.value-text-only').getByText('Normal left ovary. The right ovary contains a complex mass. No free fluid in the pelvis.')).toBeVisible();
 });
@@ -77,10 +71,7 @@ test('Obstetric ultrasound 1 form should save observations.', async ({ page }) =
   await bahmni.fillObstetricUltrasound1Form();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Echographie obstétricale 1')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Confirmed Pregnancy')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Yes')).toBeVisible();
@@ -118,10 +109,7 @@ test('Obstetric ultrasound 2 form should save observations.', async ({ page }) =
   await bahmni.fillObstetricUltrasound2Form();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Echographie obstétricale 2')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Number of Fetuses')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('1', {exact: true}).nth(0)).toBeVisible();
@@ -165,10 +153,7 @@ test('Obstetric ultrasound 3 form should save observations.', async ({ page }) =
   await bahmni.fillObstetricUltrasound3Form();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Echographie obstétricale 3')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Number of Fetuses')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('2', {exact: true}).nth(0)).toBeVisible();
@@ -193,10 +178,7 @@ test('Physical examination form should save observations.', async ({ page }) => 
   await bahmni.fillPhysicalExaminationForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Examen physique')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('General Examination')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Normal').nth(0)).toBeVisible();
@@ -219,10 +201,7 @@ test('Means of transportation form should save observations.', async ({ page }) 
   await bahmni.fillMeansOfTransportationForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Moyen de transport')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Mode of Arrival', { exact: true })).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Minibus')).toBeVisible();
@@ -239,10 +218,7 @@ test('Family planning form should save observations.', async ({ page }) => {
   await bahmni.fillFamilyPlanningForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Planification familiale')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('FP administred')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Depo Provera Injection')).toBeVisible();
@@ -263,10 +239,7 @@ test('Prenatal consultation form should save observations.', async ({ page }) =>
   await bahmni.fillPrenatalConsultationForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Consultation prénatale')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Visit number')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Three')).toBeVisible();
@@ -296,10 +269,7 @@ test('Reference form should save observations.', async ({ page }) => {
   await bahmni.fillReferenceForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Référence')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Referred By')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Doctor Fredric Hanandez')).toBeVisible();
@@ -320,10 +290,7 @@ test('New case of tuberculosis form should save observations.', async ({ page })
   await bahmni.fillNewCaseOfTuberculosisForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Nouveau cas de tuberculose')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Number of contacts identified')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('16', {exact: true}).nth(0)).toBeVisible();
@@ -363,10 +330,7 @@ test('Triage form should save observations.', async ({ page }) => {
   await bahmni.fillTriageForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Triage', {exact: true})).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Triage level')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Emergency')).toBeVisible();
@@ -383,9 +347,7 @@ test('Reason for consultation form should save observations.', async ({ page }) 
   await bahmni.fillReasonForConsultationForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Motif de consultation', {exact: true})).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Reason for Consultation', {exact: true})).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Assault by animal suspected of rabies')).toBeVisible();
@@ -408,10 +370,7 @@ test('Unauthorized departure form should save observations.', async ({ page }) =
   await bahmni.fillUnauthorizedDepartureForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Départ non autorisé', {exact: true})).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Left without permission')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('No', {exact: true}).nth(0)).toBeVisible();
@@ -430,10 +389,7 @@ test('Vital signs form should save observations.', async ({ page }) => {
   await bahmni.fillVitalSignsForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Signes vitaux', {exact: true})).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Vital Signs')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Pain Scale')).toBeVisible();
@@ -464,10 +420,7 @@ test('Gynecological examination form should save observations.', async ({ page }
   await bahmni.fillGynecologicalExaminationForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Examen gynécologique', {exact: true})).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Age at Menarche')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('14 Years')).toBeVisible();
@@ -500,10 +453,7 @@ test('Emergency monitoring form should save observations.', async ({ page }) => 
   await bahmni.fillEmergencyMonitoringForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Suivi d’urgences')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Date/Time')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('19 Aug 24 4:30 pm')).toBeVisible();
@@ -525,10 +475,7 @@ test('Vaccinations form should save observations.', async ({ page }) => {
   await bahmni.fillVaccinationsForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Vaccinations', {exact: true}).nth(0)).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Pentavalent Vaccination')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Sequence number', {exact: true})).toBeVisible();
@@ -552,10 +499,7 @@ test('Nutrition form should save observations.', async ({ page }) => {
   await bahmni.fillNutritionForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Nutrition', {exact: true}).nth(0)).toBeVisible();
   await expect(page.locator('#observationSection').getByText('First Visit')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('No', {exact: true}).nth(0)).toBeVisible();
@@ -600,10 +544,7 @@ test('Systems review form should save observations.', async ({ page }) => {
   await bahmni.fillSystemsReviewForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Examen des systèmes', {exact: true}).nth(0)).toBeVisible();
   await expect(page.locator('#observationSection').getByText('General Set')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Night sweats')).toBeVisible();
@@ -685,10 +626,7 @@ test('Health history form should save observations.', async ({ page }) => {
   await bahmni.fillHealthHistoryForm();
 
   // verify
-  await page.locator('#dashboard-link span.patient-name').click();
-  await delay(5000);
-  await expect(page.locator('a.visit')).toBeVisible();
-  await page.locator('a.visit').click();
+  await bahmni.navigateToVisitsDashboard();
   await expect(page.getByText('Historique de santé', {exact: true}).nth(0)).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Insect bites and stings')).toBeVisible();
   await expect(page.locator('#observationSection').getByText('Reason', {exact: true}).first()).toBeVisible();

--- a/e2e/utils/configs/globalSetup.ts
+++ b/e2e/utils/configs/globalSetup.ts
@@ -13,6 +13,7 @@ dotenv.config();
 
 export const BAHMNI_URL = `${process.env.TEST_ENVIRONMENT}` == 'uat' ? `${process.env.BAHMNI_URL_UAT}` : `${process.env.BAHMNI_URL_DEV}`;
 export const ODOO_URL = `${process.env.TEST_ENVIRONMENT}` == 'uat' ? `${process.env.ODOO_URL_UAT}` : `${process.env.ODOO_URL_DEV}`;
+export const OPENELIS_URL = `${process.env.TEST_ENVIRONMENT}` == 'uat' ? `${process.env.OPENELIS_URL_UAT}` : `${process.env.OPENELIS_URL_DEV}`;
 
 async function globalSetup() {
   const requestContext = await request.newContext();

--- a/e2e/utils/functions/bahmni.ts
+++ b/e2e/utils/functions/bahmni.ts
@@ -81,10 +81,18 @@ export class Bahmni {
     await expect(this.page.getByText(/lab samples/i)).toBeVisible();
   }
 
+  async navigateToVisitsDashboard() {
+    await this.page.locator('#dashboard-link span.patient-name').click();
+    await delay(5000);
+    await expect(this.page.locator('a.visit')).toBeVisible();
+    await this.page.locator('a.visit').click();
+  }
+
   async createLabOrder() {
     await this.page.getByText('Blood', { exact: true }).click();
     await this.page.getByText('Malaria').click();
     await this.save();
+    await delay(5000);
   }
 
   async reviseLabOrder() {
@@ -92,12 +100,14 @@ export class Bahmni {
     await this.page.locator('#selected-orders li').filter({ hasText: 'Malaria' }).locator('i').nth(1).click();
     await this.page.getByText(/hematocrit/i).click();
     await this.save();
+    await delay(5000);
   }
 
   async discontinueLabOrder() {
     await this.page.getByText('Blood', { exact: true }).click();
     await this.page.locator('#selected-orders li').filter({ hasText: 'Malaria' }).locator('i').nth(1).click();
     await this.save();
+    await delay(5000);
   }
 
   async navigateToPatientDashboard() {

--- a/e2e/utils/functions/odoo.ts
+++ b/e2e/utils/functions/odoo.ts
@@ -1,5 +1,5 @@
 import { expect, Page } from '@playwright/test';
-import { delay, patientName } from './bahmni';
+import { patientName } from './bahmni';
 import { ODOO_URL } from '../configs/globalSetup';
 
 export class Odoo {

--- a/e2e/utils/functions/openelis.ts
+++ b/e2e/utils/functions/openelis.ts
@@ -1,0 +1,58 @@
+import { expect, Page } from '@playwright/test';
+import { OPENELIS_URL } from '../configs/globalSetup';
+import { delay, patientName } from './bahmni';
+
+export class OpenELIS {
+  constructor(readonly page: Page) {}
+
+  async open() {
+    await this.page.goto(`${OPENELIS_URL}`);
+    await this.page.locator("input[name='loginName']").fill(`${process.env.OPENELIS_USERNAME}`);
+    await this.page.locator("input[name='password']").fill(`${process.env.OPENELIS_PASSWORD}`);
+    await this.page.locator('#submitButton').click();
+    await expect(this.page).toHaveURL(/.*openelis/);
+    await delay(6000);
+  }
+
+  async searchClient() {
+    await this.page.locator('#menu_labDashboard').click();
+    await delay(5000);
+    await this.page.locator('input#refreshButton').click();
+    await expect(this.page.locator('input[type=text]').nth(1)).toBeVisible();
+    await this.page.locator('input[type=text]').nth(1).type(`${patientName.givenName + ' ' + patientName.familyName}`);
+  }
+
+  async collectSample() {
+    await this.page.locator('#todaySamplesToCollectListContainer-slick-grid div.slick-viewport div.slick-cell.l6.r6.cell-title a').click();
+    await this.page.locator('#orderDisplay tbody input.textButton').click();
+    await this.page.locator('#saveButtonId').first().click();
+  }
+
+  async enterCodedResults() {
+    await this.page.locator('#result').first().click();
+    await this.page.locator('#results_1').selectOption('Negatif');
+    await this.page.locator('#saveButtonId').first().click();
+  }
+
+  async enterNumericalResults() {
+    await this.page.locator('#result').first().click();
+    await this.page.locator('#results_1').click();
+    await this.page.locator('#results_1').fill('13.7');
+    await this.page.locator('#cell_1').click();
+    await this.page.locator('#saveButtonId').first().click();
+  }
+
+  async enterFreeTextResults() {
+    await this.page.locator('#result').first().click();
+    await this.page.locator('#results_1').fill('Abnormal level');
+    await this.page.locator('#abnormalId_1').click();
+    await this.page.locator('#saveButtonId').first().click();
+  }
+
+  async validateLabResults() {
+    await this.page.locator('a#validate').first().click();
+    await this.page.locator('#accepted_0').check();
+    await this.page.locator('#saveButtonId').first().click();
+    await delay(15000);
+  }
+}


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/C2C-346

Description: This PR adds E2E tests for Bahmni-OpenELIS flows and covers the following test cases;

-  Ordering a lab test for a Bahmni patient creates the corresponding OpenELIS client with a filled analysis request
-  Editing the details of a Bahmni patient with a synced lab order edits the corresponding OpenELIS client details.
-  Revising a synced Bahmni lab order edits the corresponding OpenELIS client analysis request.
-  Voiding a synced OpenMRS lab order cancels the corresponding OpenElis analysis request.
-   Published coded lab results from OpenELIS are viewable in the Bahmni lab results viewer.
-   Published numeric lab results from OpenELIS are viewable in the Bahmni lab results lab results viewer.
-   Published free lab results from OpenELIS are viewable in the Bahmni lab results viewer.
