### PR TITLE
C2C-395: Add e2e tests for postnatal visit

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,13 +33,6 @@ jobs:
         with:
           node-version: 20
 
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-
       - name: Install dependencies
         run: yarn install
 

--- a/e2e/tests/bahmni-odoo-flows.spec.ts
+++ b/e2e/tests/bahmni-odoo-flows.spec.ts
@@ -15,7 +15,9 @@ test.beforeEach(async ({ page }) => {
   await expect(page.getByText(/clinical/i)).toBeVisible();
   await expect(page.getByText(/admin/i)).toBeVisible();
   await expect(page.getByText(/patient documents/i)).toBeVisible();
-  await bahmni.registerPatient();
+  await bahmni.navigateToPatientRegistationPage();
+  await bahmni.enterPatientDetails();
+  await bahmni.startPatientVisit();
   await bahmni.navigateToPatientDashboard();
 });
 
@@ -47,7 +49,7 @@ test('Editing the details of a Bahmni patient with a synced lab order edits the 
 
   // replay
   await page.goto(`${BAHMNI_URL}`);
-  await bahmni.navigateToPatientRegistationForm();
+  await bahmni.navigateToPatientRegistationPage();
   await bahmni.updatePatientDetails();
 
   // verify
@@ -136,7 +138,7 @@ test('Editing the details of a Bahmni patient with a synced drug order edits the
 
   // replay
   await page.goto(`${BAHMNI_URL}`);
-  await bahmni.navigateToPatientRegistationForm();
+  await bahmni.navigateToPatientRegistationPage();
   await bahmni.updatePatientDetails();
 
   // verify

--- a/e2e/tests/bahmni-openelis-flows.spec.ts
+++ b/e2e/tests/bahmni-openelis-flows.spec.ts
@@ -15,7 +15,9 @@ test.beforeEach(async ({ page }) => {
   await expect(page.getByText(/clinical/i)).toBeVisible();
   await expect(page.getByText(/admin/i)).toBeVisible();
   await expect(page.getByText(/patient documents/i)).toBeVisible();
-  await bahmni.registerPatient();
+  await bahmni.navigateToPatientRegistationPage();
+  await bahmni.enterPatientDetails();
+  await bahmni.startPatientVisit();
   await bahmni.navigateToPatientDashboard();
 });
 
@@ -34,7 +36,6 @@ test('Ordering a lab test for a Bahmni patient creates the corresponding OpenEli
   await expect(page.locator('#tests_1')).toHaveValue('Malaria')
 });
 
-
 test('Editing the details of a Bahmni patient with a synced lab order edits the corresponding OpenELIS client details.', async ({ page }) => {
   // setup
   await bahmni.navigateToLabSamples();
@@ -45,7 +46,7 @@ test('Editing the details of a Bahmni patient with a synced lab order edits the 
 
   // replay
   await page.goto(`${BAHMNI_URL}`);
-  await bahmni.navigateToPatientRegistationForm();
+  await bahmni.navigateToPatientRegistationPage();
   await bahmni.updatePatientDetails();
 
   // verify

--- a/e2e/tests/diagnosis.spec.ts
+++ b/e2e/tests/diagnosis.spec.ts
@@ -16,7 +16,9 @@ test.beforeEach(async ({ page }) => {
 
 test('Create and revise a diagnosis.', async ({ page }) => {
   // setup
-  await bahmni.registerPatient();
+  await bahmni.navigateToPatientRegistationPage();
+  await bahmni.enterPatientDetails();
+  await bahmni.startPatientVisit();
 
   // replay
   await bahmni.navigateToPatientDashboard();

--- a/e2e/tests/lab-orders.spec.ts
+++ b/e2e/tests/lab-orders.spec.ts
@@ -15,7 +15,9 @@ test.beforeEach(async ({ page }) => {
 
 test('Create, revise and discontinue lab tests.', async ({ page }) => {
   // setup
-  await bahmni.registerPatient();
+  await bahmni.navigateToPatientRegistationPage();
+  await bahmni.enterPatientDetails();
+  await bahmni.startPatientVisit();
 
   // replay
   await bahmni.navigateToPatientDashboard();

--- a/e2e/tests/medications.spec.ts
+++ b/e2e/tests/medications.spec.ts
@@ -15,7 +15,9 @@ test.beforeEach(async ({ page }) => {
 
 test('Create, revise and discontinue a drug order.', async ({ page }) => {
   // setup
-  await bahmni.registerPatient();
+  await bahmni.navigateToPatientRegistationPage();
+  await bahmni.enterPatientDetails();
+  await bahmni.startPatientVisit();
 
   // replay
   await bahmni.navigateToPatientDashboard();

--- a/e2e/tests/observation.spec.ts
+++ b/e2e/tests/observation.spec.ts
@@ -11,7 +11,9 @@ test.beforeEach(async ({ page }) => {
   await expect(page.getByText(/clinical/i)).toBeVisible();
   await expect(page.getByText(/admin/i)).toBeVisible();
   await expect(page.getByText(/patient documents/i)).toBeVisible();
-  await bahmni.registerPatient();
+  await bahmni.navigateToPatientRegistationPage();
+  await bahmni.enterPatientDetails();
+  await bahmni.startPatientVisit();
   await bahmni.navigateToPatientDashboard();
 });
 

--- a/e2e/tests/patient-registration.spec.ts
+++ b/e2e/tests/patient-registration.spec.ts
@@ -18,7 +18,9 @@ test('Register and edit a patient.', async ({ page }) => {
   await expect(page.getByText(/patient documents/i)).toBeVisible();
 
   // replay
-  await bahmni.registerPatient();
+  await bahmni.navigateToPatientRegistationPage();
+  await bahmni.enterPatientDetails();
+  await bahmni.startPatientVisit();
 
   // verify creation
   await bahmni.navigateToPatientDashboard();
@@ -26,7 +28,7 @@ test('Register and edit a patient.', async ({ page }) => {
 
   // verify revision
   await page.goto(`${BAHMNI_URL}`);
-  await bahmni.navigateToPatientRegistationForm();
+  await bahmni.navigateToPatientRegistationPage();
   await bahmni.updatePatientDetails();
   await bahmni.navigateToPatientDashboard();
   await expect(page.locator('#patientContext span:nth-child(2)')).toContainText(`${patientName.updatedGivenName}` + ' ' + `${patientName.familyName}`)

--- a/e2e/tests/visits.spec.ts
+++ b/e2e/tests/visits.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+import { BAHMNI_URL } from '../utils/configs/globalSetup';
+import { Bahmni, delay, patientName } from '../utils/functions/bahmni';
+import { OpenMRS } from '../utils/functions/openmrs';
+
+let bahmni: Bahmni;
+let openmrs: OpenMRS;
+
+test.use({ video: 'on' });
+
+test.beforeEach(async ({ page }) => {
+  bahmni = new Bahmni(page);
+  openmrs = new OpenMRS(page);
+
+  await bahmni.login();
+  await expect(page.getByText(/registration/i)).toBeVisible();
+  await expect(page.getByText(/clinical/i)).toBeVisible();
+  await expect(page.getByText(/admin/i)).toBeVisible();
+  await expect(page.getByText(/patient documents/i)).toBeVisible();
+});
+
+test('Starting a postnatal visit shows the patient in the Postnatal tab and updates the MSPP visit report', async ({ page, context }) => {
+  // setup
+  await page.goto(`${BAHMNI_URL}/openmrs`);
+  await openmrs.navigateToReports();
+  await openmrs.runMSPPVisitReport();
+  await expect(page.getByRole('link', { name: /view report/i })).toBeVisible();
+  await page.getByRole('link', { name: /view report/i }).click();
+  const newPage = await context.waitForEvent('page');
+  await newPage.bringToFront();
+  await expect(newPage.getByText('MSPP Visits Report').nth(0)).toBeVisible(), delay(1000);
+  let rawText = await newPage.locator('tr:has-text("Total") td:nth-of-type(2)').textContent();
+  const initialVisitsCount = Number(rawText?.trim());
+
+  // replay
+  await page.bringToFront();
+  await page.goto(`${BAHMNI_URL}/bahmni/registration`);
+  await bahmni.enterPatientDetails();
+  await bahmni.startPostnatalVisit();
+  await page.goto(`${BAHMNI_URL}/bahmni/home`);
+  await page.getByRole('link', { name: /clinical/i }).click();
+  await expect(page.getByRole('link', { name: /postnatal/i })).toBeVisible();
+
+  // verify
+  await page.getByRole('link', { name: /postnatal/i }).click(), delay(2000);
+  await page.locator('input[type="text"]').fill(`${patientName.givenName + ' ' + patientName.familyName}`), delay(2000);
+  await expect(page.locator('li.active-patient .patient-name', { hasText: `${patientName.givenName + ' ' + patientName.familyName}` })).toBeVisible();
+  await page.goto(`${BAHMNI_URL}/openmrs`);
+  await openmrs.navigateToReports();
+  await openmrs.runMSPPVisitReport();
+  await expect(page.getByRole('link', { name: /view report/i })).toBeVisible();
+  await page.getByRole('link', { name: /view report/i }).click();
+  await newPage.bringToFront();
+  await expect(newPage.getByText(/MSPP Visits Report/).nth(0)).toBeVisible(), delay(1000);
+  rawText = await newPage.locator('tr:has-text("Total") td:nth-of-type(2)').textContent();
+  let updatedVisitsCount = Number(rawText?.trim());
+  await expect(updatedVisitsCount).toBe(initialVisitsCount + 1);
+});
+
+test.afterEach(async ({ page }) => {
+  await bahmni.voidPatient();
+  await page.close();
+});

--- a/e2e/tests/visits.spec.ts
+++ b/e2e/tests/visits.spec.ts
@@ -6,8 +6,6 @@ import { OpenMRS } from '../utils/functions/openmrs';
 let bahmni: Bahmni;
 let openmrs: OpenMRS;
 
-test.use({ video: 'on' });
-
 test.beforeEach(async ({ page }) => {
   bahmni = new Bahmni(page);
   openmrs = new OpenMRS(page);

--- a/e2e/utils/functions/bahmni.ts
+++ b/e2e/utils/functions/bahmni.ts
@@ -27,13 +27,16 @@ export class Bahmni {
     await expect(this.page).toHaveURL(/.*home/);
   }
 
-  async registerPatient() {
+  async navigateToRegistrationPage() {
+    await this.page.goto(`${BAHMNI_URL}/bahmni/registration`);
+  }
+
+  async enterPatientDetails() {
     patientName = {
       givenName : `e2e_test_${Array.from({ length: 4 }, () => String.fromCharCode(Math.floor(Math.random() * 26) + 97)).join('')}`,
       familyName : `${Array.from({ length: 8 }, () => String.fromCharCode(Math.floor(Math.random() * 26) + 97)).join('')}`, 
       updatedGivenName : `${Array.from({ length: 8 }, () => String.fromCharCode(Math.floor(Math.random() * 26) + 97)).join('')}`,
     }
-    await this.page.goto(`${BAHMNI_URL}/bahmni/registration`);
     await this.page.locator('a').filter({ hasText: /create new/i }).click();
     await expect(this.page.getByText('Address Information')).toBeVisible();
     await expect(this.page.getByText('Additional Identifiers')).toBeVisible();
@@ -45,7 +48,19 @@ export class Bahmni {
     await this.page.locator('#familyName').fill(`${patientName.familyName}`);
     await this.page.locator('#gender').selectOption('F');
     await this.page.locator('#ageYears').fill(`${Math.floor(Math.random() * 99)}`);
+  }
+
+  async startPatientVisit() {
     await this.page.locator('#view-content div>ul>li button').click();
+    await expect(this.page.getByRole('button', { name: /save/i })).toBeEnabled();
+    await this.page.getByRole('button', { name: /priority/i }).click();
+    await this.page.getByRole('button', { name: /save/i }).click();
+    await expect(this.page.getByText('error')).not.toBeVisible();
+  }
+
+  async startPostnatalVisit() {
+    await this.page.locator('button[bm-pop-over-trigger]').click();
+    await this.page.getByRole('button', { name: 'Start Post-natale visit' }).click();
     await expect(this.page.getByRole('button', { name: /save/i })).toBeEnabled();
     await this.page.getByRole('button', { name: /priority/i }).click();
     await this.page.getByRole('button', { name: /save/i }).click();
@@ -128,7 +143,7 @@ export class Bahmni {
     await this.page.getByRole('button', { name: /add new obs form/i  }).click();
   }
 
-  async navigateToPatientRegistationForm() {
+  async navigateToPatientRegistationPage() {
     await this.page.getByRole('link', { name: /registration/i }).click();
   }
 

--- a/e2e/utils/functions/openmrs.ts
+++ b/e2e/utils/functions/openmrs.ts
@@ -1,0 +1,43 @@
+import { Page, expect } from '@playwright/test';
+import { delay } from './bahmni';
+
+const date = new Date();
+export const currentDate = `${String(date.getDate()).padStart(2, '0')}/${String(date.getMonth() + 1).padStart(2, '0')}/${date.getFullYear()}`;
+date.setDate(date.getDate() - 1);
+export const previousDate = `${date.getDate().toString().padStart(2, '0')}/${(date.getMonth() + 1).toString().padStart(2, '0')}/${date.getFullYear()}`;
+
+export class OpenMRS {
+  constructor(readonly page: Page) {}
+
+  async startPatientVisit() {
+    await this.page.locator('#view-content div>ul>li button').click();
+    await expect(this.page.getByRole('button', { name: /save/i })).toBeEnabled();
+    await this.page.getByRole('button', { name: /priority/i }).click();
+    await this.page.getByRole('button', { name: /save/i }).click();
+    await expect(this.page.getByText('error')).not.toBeVisible();
+  }
+
+  async startPostnatalVisit() {
+    await this.page.locator('button[bm-pop-over-trigger]').click();
+    await this.page.getByRole('button', { name: 'Start Post-natale visit' }).click();
+    await expect(this.page.getByRole('button', { name: /save/i })).toBeEnabled();
+    await this.page.getByRole('button', { name: /priority/i }).click();
+    await this.page.getByRole('button', { name: /save/i }).click();
+    await expect(this.page.getByText('error')).not.toBeVisible();
+  }
+
+  async navigateToReports() {
+    await this.page.getByRole('link', { name: /Administration/i, exact: true }).click();
+    await expect(this.page.getByRole('link', { name: 'Report Administration' }).first()).toBeVisible();
+    await this.page.getByRole('link', { name: 'Report Administration' }).first().click();
+  }
+
+  async runMSPPVisitReport() {
+    await this.page.getByRole('row', { name: 'MSPP Visits Report' }).getByRole('link').nth(2).click();
+    await this.page.locator('#userEnteredParamstartDate').fill(`${previousDate}`);
+    await this.page.locator('#userEnteredParamendDate').fill(`${currentDate}`), delay(1500);
+    await expect(this.page.getByRole('button', { name: 'Request Report' })).toBeVisible();
+    await this.page.getByRole('button', { name: 'Request Report' }).focus();
+    await this.page.getByRole('button', { name: 'Request Report' }).click(), delay(6000);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MPL-2.0",
   "description": "These are end-to-end automated tests covering Bahmni distro C2C workflows",
   "scripts": {
-    "e2e-tests-c2c": "npx playwright test visits"
+    "e2e-tests-c2c": "npx playwright test"
   },
   "keywords": [],
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MPL-2.0",
   "description": "These are end-to-end automated tests covering Bahmni distro C2C workflows",
   "scripts": {
-    "e2e-tests-c2c": "npx playwright test"
+    "e2e-tests-c2c": "npx playwright test visits"
   },
   "keywords": [],
   "devDependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,7 @@ const config: PlaywrightTestConfig = {
       name: 'chromium',
       use: {
         ...devices['Desktop Chromium'],
-        viewport: { width: 1920, height: 1080 }
+        viewport: { width: 1920, height: 1080 },
       },
     },
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,14 +8,13 @@ const config: PlaywrightTestConfig = {
   expect: {
     timeout: 40 * 1000,
   },
-  fullyParallel: true,
+  fullyParallel: false,
   forbidOnly: !!process.env.CI,
   workers: process.env.CI ? 1 : 1,
   retries: 0,
   reporter: process.env.CI ? [['junit', { outputFile: 'results.xml' }], ['html']] : [['html']],
   use: {
     baseURL: `${process.env.BAHMNI_URL_DEV}`,
-    storageState: 'e2e/storageState.json',
     ignoreHTTPSErrors: true,
   },
   projects: [
@@ -24,6 +23,10 @@ const config: PlaywrightTestConfig = {
       use: {
         ...devices['Desktop Chromium'],
         viewport: { width: 1920, height: 1080 },
+        storageState: undefined,
+        launchOptions: {
+          args: ['--disable-cache', '--disable-application-cache']
+        },
       },
     },
   ],


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/C2C-395

This PR adds E2E tests for postnatal visits. It includes the following steps:

- Logs into the EMR.
- Runs the MSSP visits report and records the initial visit count.
- Registers a new patient and starts a postnatal visit.
- Checks the clinical dashboard to confirm the new patient appears under the Postnatal tab.
- Runs the MSSP visits report again and records the updated visit count.
- Confirms the visit count increased by 1.