### PR TITLE
Use exact match for `Malaria` text selector to avoid strict mode violation.

### DIFF
--- a/e2e/tests/lab-orders.spec.ts
+++ b/e2e/tests/lab-orders.spec.ts
@@ -23,7 +23,7 @@ test('Create, revise and discontinue lab tests.', async ({ page }) => {
   await bahmni.navigateToPatientDashboard();
   await bahmni.navigateToLabSamples();
   await page.getByText('Blood', { exact: true }).click();
-  await page.getByText('Malaria').click();
+  await page.getByText('Malaria', { exact: true }).click();
   await page.getByText('Urine').click();
   await page.getByText('Gravindex').click();
   await page.getByText('Stool').click();

--- a/e2e/utils/functions/bahmni.ts
+++ b/e2e/utils/functions/bahmni.ts
@@ -111,7 +111,7 @@ export class Bahmni {
 
   async createLabOrder() {
     await this.page.getByText('Blood', { exact: true }).click();
-    await this.page.getByText('Malaria').click();
+    await this.page.getByText('Malaria', { exact: true }).click();
     await this.save();
     await delay(5000);
   }


### PR DESCRIPTION
This PR fixes strict mode violation when clicking on the element.